### PR TITLE
Abstracts where available

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,187 +1,213 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <title>Just BibTeX</title>
-    <style>
-      /* Catppuccin Theme (Mocha variant) */
-      :root {
-        --base: #1e1e2e; /* Base background */
-        --text: #cdd6f4; /* Primary text */
-        --accent: #89b4fa; /* Accent color for buttons and links */
-        --accent-hover: #74a7f8; /* Accent color on hover */
-        --surface: #313244; /* Surface color for input fields */
-        --surface-hover: #45475a; /* Surface color on hover */
-        --muted: #6c7086; /* Muted text */
-        --error: #f38ba8; /* Error messages */
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Just BibTeX</title>
+  <style>
+    /* Catppuccin Theme (Mocha variant) */
+    :root {
+      --base: #1e1e2e;
+      /* Base background */
+      --text: #cdd6f4;
+      /* Primary text */
+      --accent: #89b4fa;
+      /* Accent color for buttons and links */
+      --accent-hover: #74a7f8;
+      /* Accent color on hover */
+      --surface: #313244;
+      /* Surface color for input fields */
+      --surface-hover: #45475a;
+      /* Surface color on hover */
+      --muted: #6c7086;
+      /* Muted text */
+      --error: #f38ba8;
+      /* Error messages */
+    }
+
+    body {
+      font-family: sans-serif;
+      margin: 20px;
+      background-color: var(--base);
+      color: var(--text);
+    }
+
+    h1 {
+      color: var(--text);
+      margin-bottom: 20px;
+    }
+
+    textarea {
+      width: 100%;
+      height: 350px;
+      border: 1px solid var(--surface);
+      padding: 10px;
+      font-family: monospace;
+      font-size: 14px;
+      background-color: var(--base);
+      color: var(--text);
+      border-radius: 8px;
+      resize: vertical;
+    }
+
+    #doiInput {
+      width: 60%;
+      padding: 10px;
+      font-size: 16px;
+      border: 1px solid var(--surface);
+      border-radius: 8px;
+      background-color: var(--base);
+      color: var(--text);
+      margin-right: 10px;
+    }
+
+    #doiInput::placeholder {
+      color: var(--muted);
+    }
+
+    button {
+      font-size: 16px;
+      padding: 10px 20px;
+      cursor: pointer;
+      background-color: var(--accent);
+      color: var(--base);
+      border: none;
+      border-radius: 8px;
+      transition: background-color 0.2s ease;
+    }
+
+    button:hover {
+      background-color: var(--accent-hover);
+    }
+
+    .entry {
+      margin: 10px 0;
+    }
+
+    #entries {
+      margin-top: 20px;
+    }
+
+    /* Additional styling for buttons inside #entries */
+    #entries button {
+      margin-top: 10px;
+      margin-right: 10px;
+    }
+
+    /* Error message styling */
+    .error {
+      color: var(--error);
+      margin-top: 10px;
+    }
+
+    /* Footer styling */
+    footer {
+      margin-top: auto;
+      text-align: center;
+      padding: 20px 0;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    footer a {
+      color: var(--muted);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+
+    footer a:hover {
+      color: var(--accent);
+    }
+
+    /* GitHub icon styling */
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+      vertical-align: text-bottom;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Just BibTeX</h1>
+  <input id="doiInput" type="text" placeholder="Enter DOI, arXiv URL, or Journal URL" />
+  <button onclick="addBibtex()">Fetch Bibtex & Add</button>
+  <div id="entries"></div>
+  <!-- Footer -->
+  <footer>
+    <a href="https://github.com/ParticularlyPythonicBS/justBibTex" target="_blank" rel="noopener noreferrer">
+      <!-- GitHub icon -->
+      <svg class="github-icon" viewBox="0 0 16 16" aria-hidden="true">
+        <path fill-rule="evenodd"
+          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+      </svg>
+      <span>View on GitHub</span>
+    </a>
+  </footer>
+
+  <script>
+    function formatBibtex(bib) {
+      return bib
+        .replace(/\r\n/g, '\n')
+        .replace(/\n{2,}/g, '\n\n')
+        .trim();
+    }
+
+    function loadEntries() {
+      const saved = localStorage.getItem('bibtexEntries');
+      return saved ? JSON.parse(saved) : [];
+    }
+
+    function saveEntries(entries) {
+      localStorage.setItem('bibtexEntries', JSON.stringify(entries));
+    }
+
+    async function fetchBibtexFromDOI(doi) {
+      // Fetch BibTeX from DOI
+      const bibtexResponse = await fetch(`https://doi.org/${encodeURIComponent(doi)}`, {
+        headers: { Accept: 'application/x-bibtex' },
+      });
+      if (!bibtexResponse.ok) throw new Error('BibTeX not found for this DOI.');
+      let bibtex = await bibtexResponse.text();
+
+      // Fetch summary using CrossRef API
+      const crossrefUrl = `https://api.crossref.org/works/${doi}`;
+      const crossrefResponse = await fetch(crossrefUrl);
+      if (!crossrefResponse.ok) throw new Error('Failed to fetch summary.');
+      const crossrefData = await crossrefResponse.json();
+      console.log(crossrefData);
+      const abstractBlock = crossrefData.message.abstract || null;
+
+      const abstractMatch = abstractBlock.match(/<jats:p>(.*?)<\/jats:p>/);
+      const abstract = abstractMatch ? abstractMatch[1] : null;
+
+      // Add abstract to BibTeX
+      if (abstract) {
+        bibtex = bibtex.replace(/\}\s*$/, `,\n  abstract = {${abstract}}\n}`);
       }
+      return bibtex;
+    }
 
-      body {
-        font-family: sans-serif;
-        margin: 20px;
-        background-color: var(--base);
-        color: var(--text);
-      }
+    async function fetchBibtexFromArxiv(arxivId) {
+      const response = await fetch(`https://export.arxiv.org/api/query?id_list=${arxivId}`);
+      if (!response.ok) throw new Error('Failed to fetch arXiv metadata.');
+      const text = await response.text();
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(text, 'text/xml');
 
-      h1 {
-        color: var(--text);
-        margin-bottom: 20px;
-      }
+      const entry = xmlDoc.querySelector('entry');
+      if (!entry) throw new Error('No arXiv entry found.');
 
-      textarea {
-        width: 100%;
-        height: 350px;
-        border: 1px solid var(--surface);
-        padding: 10px;
-        font-family: monospace;
-        font-size: 14px;
-        background-color: var(--base);
-        color: var(--text);
-        border-radius: 8px;
-        resize: vertical;
-      }
+      const title = entry.querySelector('title').textContent.replace(/\n/g, ' ').trim();
+      const authors = Array.from(entry.querySelectorAll('author name')).map(
+        (el) => el.textContent.trim()
+      );
+      const published = new Date(entry.querySelector('published').textContent);
+      const year = published.getFullYear();
+      const summary = entry.querySelector('summary').textContent.trim();
 
-      #doiInput {
-        width: 60%;
-        padding: 10px;
-        font-size: 16px;
-        border: 1px solid var(--surface);
-        border-radius: 8px;
-        background-color: var(--base);
-        color: var(--text);
-        margin-right: 10px;
-      }
-
-      #doiInput::placeholder {
-        color: var(--muted);
-      }
-
-      button {
-        font-size: 16px;
-        padding: 10px 20px;
-        cursor: pointer;
-        background-color: var(--accent);
-        color: var(--base);
-        border: none;
-        border-radius: 8px;
-        transition: background-color 0.2s ease;
-      }
-
-      button:hover {
-        background-color: var(--accent-hover);
-      }
-
-      .entry {
-        margin: 10px 0;
-      }
-
-      #entries {
-        margin-top: 20px;
-      }
-
-      /* Additional styling for buttons inside #entries */
-      #entries button {
-        margin-top: 10px;
-        margin-right: 10px;
-      }
-
-      /* Error message styling */
-      .error {
-        color: var(--error);
-        margin-top: 10px;
-      }
-
-      /* Footer styling */
-      footer {
-        margin-top: auto;
-        text-align: center;
-        padding: 20px 0;
-        color: var(--muted);
-        font-size: 14px;
-      }
-
-      footer a {
-        color: var(--muted);
-        text-decoration: none;
-        transition: color 0.2s ease;
-      }
-
-      footer a:hover {
-        color: var(--accent);
-      }
-
-      /* GitHub icon styling */
-      .github-icon {
-        width: 16px;
-        height: 16px;
-        fill: currentColor;
-        vertical-align: text-bottom;
-      }
-    </style>
-  </head>
-  <body>
-    <h1>Just BibTeX</h1>
-    <input id="doiInput" type="text" placeholder="Enter DOI, arXiv URL, or Journal URL" />
-    <button onclick="addBibtex()">Fetch Bibtex & Add</button>
-    <div id="entries"></div>
-    <!-- Footer -->
-    <footer>
-      <a href="https://github.com/ParticularlyPythonicBS/justBibTex" target="_blank" rel="noopener noreferrer">
-        <!-- GitHub icon -->
-        <svg class="github-icon" viewBox="0 0 16 16" aria-hidden="true">
-          <path
-            fill-rule="evenodd"
-            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
-          />
-        </svg>
-        <span>View on GitHub</span>
-      </a>
-    </footer>
-
-    <script>
-      function formatBibtex(bib) {
-        return bib
-          .replace(/\r\n/g, '\n')
-          .replace(/\n{2,}/g, '\n\n')
-          .trim();
-      }
-
-      function loadEntries() {
-        const saved = localStorage.getItem('bibtexEntries');
-        return saved ? JSON.parse(saved) : [];
-      }
-
-      function saveEntries(entries) {
-        localStorage.setItem('bibtexEntries', JSON.stringify(entries));
-      }
-
-      async function fetchBibtexFromDOI(doi) {
-        const response = await fetch(`https://doi.org/${encodeURIComponent(doi)}`, {
-          headers: { Accept: 'application/x-bibtex' }
-        });
-        if (!response.ok) throw new Error('BibTeX not found for this DOI.');
-        return await response.text();
-      }
-
-      async function fetchBibtexFromArxiv(arxivId) {
-        const response = await fetch(`https://export.arxiv.org/api/query?id_list=${arxivId}`);
-        if (!response.ok) throw new Error('Failed to fetch arXiv metadata.');
-        const text = await response.text();
-        const parser = new DOMParser();
-        const xmlDoc = parser.parseFromString(text, 'text/xml');
-
-        const entry = xmlDoc.querySelector('entry');
-        if (!entry) throw new Error('No arXiv entry found.');
-
-        const title = entry.querySelector('title').textContent.replace(/\n/g, ' ').trim();
-        const authors = Array.from(entry.querySelectorAll('author name')).map(
-          (el) => el.textContent.trim()
-        );
-        const published = new Date(entry.querySelector('published').textContent);
-        const year = published.getFullYear();
-        const summary = entry.querySelector('summary').textContent.trim();
-
-        const bibtex = `@article{${arxivId},
+      const bibtex = `@article{${arxivId},
   title = {${title}},
   author = {${authors.join(' and ')}},
   year = {${year}},
@@ -193,111 +219,123 @@
   abstract = {${summary}}
 }`;
 
-        return bibtex;
+      return bibtex;
+    }
+
+    async function fetchBibtexFromUrl(url) {
+      // Extract DOI from the URL if possible
+      const doiMatch = url.match(/10\.\d{4,}\/\S+/);
+      if (doiMatch) {
+        return await fetchBibtexFromDOI(doiMatch[0]);
       }
 
-      async function fetchBibtexFromUrl(url) {
-        // Extract DOI from the URL if possible
-        const doiMatch = url.match(/10\.\d{4,}\/\S+/);
-        if (doiMatch) {
-          return await fetchBibtexFromDOI(doiMatch[0]);
+      // Fallback: Use CrossRef API to fetch BibTeX
+      const response = await fetch(`https://api.crossref.org/works/${encodeURIComponent(url)}/transform/application/x-bibtex`);
+      if (!response.ok) throw new Error('BibTeX not found for this URL.');
+      let bibtex = await response.text();
+
+      // Fetch summary using CrossRef API
+      const crossrefUrl = `https://api.crossref.org/works/${encodeURIComponent(url)}`;
+      const crossrefResponse = await fetch(crossrefUrl);
+      if (!crossrefResponse.ok) throw new Error('Failed to fetch summary.');
+      const crossrefData = await crossrefResponse.json();
+      console.log(crossrefData);
+      const abstractBlock = crossrefData.message.abstract || null;
+
+      const abstractMatch = abstractBlock.match(/<jats:p>(.*?)<\/jats:p>/);
+      const abstract = abstractMatch ? abstractMatch[1] : null;
+    }
+
+    async function addBibtex() {
+      const input = document.getElementById('doiInput').value.trim();
+      if (!input) {
+        alert('Please enter a DOI, arXiv URL, or Journal URL.');
+        return;
+      }
+
+      try {
+        let bibtex;
+        if (/^10\.\d{4,}\/\S+$/.test(input)) {
+          // Handle DOI
+          bibtex = await fetchBibtexFromDOI(input);
+        } else if (/arxiv\.org\/abs\/|^arxiv:/i.test(input)) {
+          // Handle arXiv URL or ID
+          const arxivId = input.match(/(\d{4}\.\d{4,5}(v\d+)?)/)?.[0];
+          if (!arxivId) throw new Error('Invalid arXiv URL or ID.');
+          bibtex = await fetchBibtexFromArxiv(arxivId);
+        } else {
+          // Handle journal URLs
+          bibtex = await fetchBibtexFromUrl(input);
         }
 
-        // Fallback: Use CrossRef API to fetch BibTeX
-        const response = await fetch(`https://api.crossref.org/works/${encodeURIComponent(url)}/transform/application/x-bibtex`);
-        if (!response.ok) throw new Error('BibTeX not found for this URL.');
-        return await response.text();
-      }
-
-      async function addBibtex() {
-        const input = document.getElementById('doiInput').value.trim();
-        if (!input) {
-          alert('Please enter a DOI, arXiv URL, or Journal URL.');
+        const entries = loadEntries();
+        if (entries.includes(bibtex)) {
+          alert('This entry already exists.');
           return;
         }
 
+        entries.push(bibtex);
+        saveEntries(entries);
+        renderEntries();
+        document.getElementById('doiInput').value = ''; // Clear input
+      } catch (err) {
+        alert(err.message);
+      }
+    }
+
+    function renderEntries() {
+      const container = document.getElementById('entries');
+      container.innerHTML = '';
+      const entries = loadEntries().map(formatBibtex);
+      const combined = entries.join('\n\n');
+
+      const textarea = document.createElement('textarea');
+      textarea.value = combined;
+      container.appendChild(textarea);
+
+      // Copy button
+      const copyBtn = document.createElement('button');
+      copyBtn.textContent = 'Copy';
+      copyBtn.onclick = () => {
+        navigator.clipboard.writeText(textarea.value);
+      };
+      container.appendChild(copyBtn);
+
+      // Download button
+      const downloadBtn = document.createElement('button');
+      downloadBtn.textContent = 'Download';
+      downloadBtn.onclick = () => {
+        const blob = new Blob([textarea.value], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'bibtex_entries.bib';
+        a.click();
+        URL.revokeObjectURL(url);
+      };
+      container.appendChild(downloadBtn);
+    }
+
+    // Handle URL-based DOI
+    async function handleUrlDoi() {
+      const path = window.location.pathname.slice(1); // Remove leading slash
+      if (/^10\.\d{4,}\/\S+$/.test(path)) {
         try {
-          let bibtex;
-          if (/^10\.\d{4,}\/\S+$/.test(input)) {
-            // Handle DOI
-            bibtex = await fetchBibtexFromDOI(input);
-          } else if (/arxiv\.org\/abs\/|^arxiv:/i.test(input)) {
-            // Handle arXiv URL or ID
-            const arxivId = input.match(/(\d{4}\.\d{4,5}(v\d+)?)/)?.[0];
-            if (!arxivId) throw new Error('Invalid arXiv URL or ID.');
-            bibtex = await fetchBibtexFromArxiv(arxivId);
-          } else {
-            // Handle journal URLs
-            bibtex = await fetchBibtexFromUrl(input);
-          }
-
-          const entries = loadEntries();
-          if (entries.includes(bibtex)) {
-            alert('This entry already exists.');
-            return;
-          }
-
-          entries.push(bibtex);
+          const bibtex = await fetchBibtexFromDOI(path);
+          const entries = [bibtex];
           saveEntries(entries);
           renderEntries();
-          document.getElementById('doiInput').value = ''; // Clear input
         } catch (err) {
           alert(err.message);
         }
       }
+    }
 
-      function renderEntries() {
-        const container = document.getElementById('entries');
-        container.innerHTML = '';
-        const entries = loadEntries().map(formatBibtex);
-        const combined = entries.join('\n\n');
+    window.onload = () => {
+      handleUrlDoi(); // Check for DOI in URL
+      renderEntries(); // Render existing entries
+    };
+  </script>
+</body>
 
-        const textarea = document.createElement('textarea');
-        textarea.value = combined;
-        container.appendChild(textarea);
-
-        // Copy button
-        const copyBtn = document.createElement('button');
-        copyBtn.textContent = 'Copy';
-        copyBtn.onclick = () => {
-          navigator.clipboard.writeText(textarea.value);
-        };
-        container.appendChild(copyBtn);
-
-        // Download button
-        const downloadBtn = document.createElement('button');
-        downloadBtn.textContent = 'Download';
-        downloadBtn.onclick = () => {
-          const blob = new Blob([textarea.value], { type: 'text/plain' });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'bibtex_entries.bib';
-          a.click();
-          URL.revokeObjectURL(url);
-        };
-        container.appendChild(downloadBtn);
-      }
-
-      // Handle URL-based DOI
-      async function handleUrlDoi() {
-        const path = window.location.pathname.slice(1); // Remove leading slash
-        if (/^10\.\d{4,}\/\S+$/.test(path)) {
-          try {
-            const bibtex = await fetchBibtexFromDOI(path);
-            const entries = [bibtex];
-            saveEntries(entries);
-            renderEntries();
-          } catch (err) {
-            alert(err.message);
-          }
-        }
-      }
-
-      window.onload = () => {
-        handleUrlDoi(); // Check for DOI in URL
-        renderEntries(); // Render existing entries
-      };
-    </script>
-  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -176,15 +176,14 @@
       const crossrefResponse = await fetch(crossrefUrl);
       if (!crossrefResponse.ok) throw new Error('Failed to fetch summary.');
       const crossrefData = await crossrefResponse.json();
-      console.log(crossrefData);
       const abstractBlock = crossrefData.message.abstract || null;
-
-      const abstractMatch = abstractBlock.match(/<jats:p>(.*?)<\/jats:p>/);
-      const abstract = abstractMatch ? abstractMatch[1] : null;
-
-      // Add abstract to BibTeX
-      if (abstract) {
-        bibtex = bibtex.replace(/\}\s*$/, `,\n  abstract = {${abstract}}\n}`);
+      if (abstractBlock){
+        const abstractMatch = abstractBlock.match(/<jats:p>(.*?)<\/jats:p>/);
+        const abstract = abstractMatch ? abstractMatch[1] : null;
+        // Add abstract to BibTeX
+        if (abstract) {
+          bibtex = bibtex.replace(/\}\s*$/, `,\n  abstract = {${abstract}}\n}`);
+        }
       }
       return bibtex;
     }
@@ -239,11 +238,16 @@
       const crossrefResponse = await fetch(crossrefUrl);
       if (!crossrefResponse.ok) throw new Error('Failed to fetch summary.');
       const crossrefData = await crossrefResponse.json();
-      console.log(crossrefData);
       const abstractBlock = crossrefData.message.abstract || null;
-
-      const abstractMatch = abstractBlock.match(/<jats:p>(.*?)<\/jats:p>/);
-      const abstract = abstractMatch ? abstractMatch[1] : null;
+      if (abstractBlock){
+        const abstractMatch = abstractBlock.match(/<jats:p>(.*?)<\/jats:p>/);
+        const abstract = abstractMatch ? abstractMatch[1] : null;
+        // Add abstract to BibTeX
+        if (abstract) {
+          bibtex = bibtex.replace(/\}\s*$/, `,\n  abstract = {${abstract}}\n}`);
+        }
+      }
+      return bibtex;
     }
 
     async function addBibtex() {

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
   primaryClass = {${entry.querySelector('category').getAttribute('term')}},
   journal = {arXiv preprint},
   url = {https://arxiv.org/abs/${arxivId}},
-  note = {${summary}}
+  abstract = {${summary}}
 }`;
 
         return bibtex;


### PR DESCRIPTION
fixes #1 

Adds abstracts to the bibtex whenever available on the crossref api.
Changes arxiv bibtex to use abstract instead of notes.